### PR TITLE
fix(service): enable default agent by default in freebsd

### DIFF
--- a/datadog/map.jinja
+++ b/datadog/map.jinja
@@ -17,7 +17,7 @@
                 'root_group': 'wheel',
             },
             'install_settings': {
-              'services': ['datadog-agent-trace', 'datadog-agent-process']
+              'services': ['datadog-agent', 'datadog-agent-trace', 'datadog-agent-process']
             },
         },
     },


### PR DESCRIPTION
Signed-off-by: Felipe Zipitria <fzipitria@perceptyx.com>

Adds default agent in FreeBSD.